### PR TITLE
Run efa-device-plugin container with non root user

### DIFF
--- a/manifest/efa-k8s-device-plugin.yml
+++ b/manifest/efa-k8s-device-plugin.yml
@@ -88,6 +88,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+            runAsUser: 1000
           volumeMounts:
             - name: device-plugin
               mountPath: /var/lib/kubelet/device-plugins


### PR DESCRIPTION
*Issue #, if available:* #8

*Description of changes:* Allow the container to be run as non root user

Kubernetes 1.25 has produced different security restrictions (https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.25)
As a result, `eksctl` tool needed to align the used plugins (Nvidia, Neuron, AWS node, etc.) with those security changes (https://github.com/weaveworks/eksctl/pull/6065). Seems that they missed patching efa-k8s-device-plugin.
I created a PR for patching it https://github.com/weaveworks/eksctl/pull/6435
Meanwhile, for applying the efa-k8s-device-plugin, use a custom yaml (add `runAsUser: 1000` field to the container execution), 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
