### PR TITLE
Schedule device plugin to p5.48xlarge instances

### DIFF
--- a/manifest/efa-k8s-device-plugin.yml
+++ b/manifest/efa-k8s-device-plugin.yml
@@ -58,6 +58,7 @@ spec:
                       - p4de.24xlarge
                       - trn1.32xlarge
                       - trn1n.32xlarge
+                      - p5.48xlarge
               - matchExpressions:
                   - key: "node.kubernetes.io/instance-type"
                     operator: In
@@ -81,6 +82,7 @@ spec:
                       - p4de.24xlarge
                       - trn1.32xlarge
                       - trn1n.32xlarge
+                      - p5.48xlarge
       hostNetwork: true
       containers:
         - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin:v0.3.3
@@ -98,5 +100,3 @@ spec:
         - name: device-plugin
           hostPath:
             path: /var/lib/kubelet/device-plugins
-
-


### PR DESCRIPTION
My understanding is that EFA should be supported on the new p5.48xlarge instance types.

This PR allows the device plugin daemonset to be scheduled to these instance types.