### PR TITLE
Add p5.48xlarge to device plugin manifest

### DIFF
--- a/manifest/efa-k8s-device-plugin.yml
+++ b/manifest/efa-k8s-device-plugin.yml
@@ -52,6 +52,7 @@ spec:
                       - r5dn.24xlarge
                       - r5n.24xlarge
                       - p4d.24xlarge
+                      - p5.48xlarge
                       - hpc6a.48xlarge
                       - dl1.24xlarge
                       - g5.48xlarge
@@ -75,6 +76,7 @@ spec:
                       - r5dn.24xlarge
                       - r5n.24xlarge
                       - p4d.24xlarge
+                      - p5.48xlarge
                       - hpc6a.48xlarge
                       - dl1.24xlarge
                       - g5.48xlarge


### PR DESCRIPTION
Adds p5.48xlarge so the DS pods will be scheduled there.

*Issue #, if available:*
None.

*Description of changes:*
Nothing in addition to the PR title. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
