### PR TITLE
updated manifest

### DIFF
--- a/manifest/efa-k8s-device-plugin.yml
+++ b/manifest/efa-k8s-device-plugin.yml
@@ -11,10 +11,6 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      # This annotation is deprecated. Kept here for backward compatibility
-      # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         name: aws-efa-k8s-device-plugin
     spec:
@@ -36,57 +32,109 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: "beta.kubernetes.io/instance-type"
-                    operator: In
-                    values:
-                      - c5n.18xlarge
-                      - c5n.metal
-                      - g4dn.metal
-                      - c5n.9xlarge
-                      - i3en.24xlarge
-                      - i3en.metal
-                      - inf1.24xlarge
-                      - m5dn.24xlarge
-                      - m5n.24xlarge
-                      - p3dn.24xlarge
-                      - r5dn.24xlarge
-                      - r5n.24xlarge
-                      - p4d.24xlarge
-                      - p5.48xlarge
-                      - hpc6a.48xlarge
-                      - dl1.24xlarge
-                      - g5.48xlarge
-                      - p4de.24xlarge
-                      - trn1.32xlarge
-                      - trn1n.32xlarge
-              - matchExpressions:
                   - key: "node.kubernetes.io/instance-type"
                     operator: In
                     values:
-                      - c5n.18xlarge
-                      - c5n.metal
-                      - c5n.9xlarge
-                      - g4dn.metal
-                      - i3en.24xlarge
-                      - i3en.metal
-                      - inf1.24xlarge
-                      - m5dn.24xlarge
-                      - m5n.24xlarge
-                      - p3dn.24xlarge
-                      - r5dn.24xlarge
-                      - r5n.24xlarge
-                      - p4d.24xlarge
-                      - p5.48xlarge
-                      - hpc6a.48xlarge
-                      - dl1.24xlarge
-                      - g5.48xlarge
-                      - p4de.24xlarge
-                      - trn1.32xlarge
-                      - trn1n.32xlarge
+                    - c5n.18xlarge
+                    - c5n.9xlarge
+                    - c5n.metal
+                    - c6a.48xlarge
+                    - c6a.metal
+                    - c6gn.16xlarge
+                    - c6i.32xlarge
+                    - c6i.metal
+                    - c6id.32xlarge
+                    - c6id.metal
+                    - c6in.32xlarge
+                    - c6in.metal
+                    - c7a.48xlarge
+                    - c7a.metal-48xl
+                    - c7g.16xlarge
+                    - c7g.metal
+                    - c7gd.16xlarge
+                    - c7gn.16xlarge
+                    - c7i.48xlarge
+                    - c7i.metal-48xl
+                    - dl1.24xlarge
+                    - dl2q.24xlarge
+                    - g4dn.12xlarge
+                    - g4dn.16xlarge
+                    - g4dn.8xlarge
+                    - g4dn.metal
+                    - g5.12xlarge
+                    - g5.16xlarge
+                    - g5.24xlarge
+                    - g5.48xlarge
+                    - g5.8xlarge
+                    - i3en.12xlarge
+                    - i3en.24xlarge
+                    - i3en.metal
+                    - i4g.16xlarge
+                    - i4i.32xlarge
+                    - i4i.metal
+                    - im4gn.16xlarge
+                    - inf1.24xlarge
+                    - m5dn.24xlarge
+                    - m5dn.metal
+                    - m5n.24xlarge
+                    - m5n.metal
+                    - m5zn.12xlarge
+                    - m5zn.metal
+                    - m6a.48xlarge
+                    - m6a.metal
+                    - m6i.32xlarge
+                    - m6i.metal
+                    - m6id.32xlarge
+                    - m6id.metal
+                    - m6idn.32xlarge
+                    - m6idn.metal
+                    - m6in.32xlarge
+                    - m6in.metal
+                    - m7a.48xlarge
+                    - m7a.metal-48xl
+                    - m7g.16xlarge
+                    - m7g.metal
+                    - m7gd.16xlarge
+                    - m7i.48xlarge
+                    - m7i.metal-48xl
+                    - p3dn.24xlarge
+                    - p4d.24xlarge
+                    - p5.48xlarge
+                    - r5dn.24xlarge
+                    - r5dn.metal
+                    - r5n.24xlarge
+                    - r5n.metal
+                    - r6a.48xlarge
+                    - r6a.metal
+                    - r6i.32xlarge
+                    - r6i.metal
+                    - r6id.32xlarge
+                    - r6id.metal
+                    - r6idn.32xlarge
+                    - r6idn.metal
+                    - r6in.32xlarge
+                    - r6in.metal
+                    - r7a.48xlarge
+                    - r7a.metal-48xl
+                    - r7g.16xlarge
+                    - r7g.metal
+                    - r7gd.16xlarge
+                    - r7i.48xlarge
+                    - r7i.metal-48xl
+                    - r7iz.32xlarge
+                    - r7iz.metal-32xl
+                    - trn1.32xlarge
+                    - trn1n.32xlarge
+                    - vt1.24xlarge
+                    - x2idn.32xlarge
+                    - x2idn.metal
+                    - x2iedn.32xlarge
+                    - x2iedn.metal
+                    - x2iezn.12xlarge
+                    - x2iezn.metal
       hostNetwork: true
       containers:
-        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin:v0.3.3
-          imagePullPolicy: Always
+        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin:v0.4.2
           name: aws-efa-k8s-device-plugin
           securityContext:
             allowPrivilegeEscalation: false
@@ -96,9 +144,11 @@ spec:
           volumeMounts:
             - name: device-plugin
               mountPath: /var/lib/kubelet/device-plugins
+          resources:
+            requests:
+              cpu:    10m
+              memory: 20Mi
       volumes:
         - name: device-plugin
           hostPath:
             path: /var/lib/kubelet/device-plugins
-
-


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* Updated manifest with latest list of EFA-capable instance types from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types
* Added latest EFA plugin version
* Removed `imagePullPolicy`
* Added CPU and Memory resource requests
* Removed `scheduler.alpha.kubernetes.io/critical-pod: ""` annotation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
