### PR TITLE
update efa-k8s-device-plugin to use v0.4.3

### DIFF
--- a/manifest/efa-k8s-device-plugin.yml
+++ b/manifest/efa-k8s-device-plugin.yml
@@ -134,7 +134,7 @@ spec:
                     - x2iezn.metal
       hostNetwork: true
       containers:
-        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin:v0.4.2
+        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin:v0.4.3
           name: aws-efa-k8s-device-plugin
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
*Description of changes:*
We have built new efa-k8s-device-plugin:v0.4.3 image which updated the baseOS image to address CVEs in it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
