### PR TITLE
update EFA plugin image to v0.5.1

### DIFF
--- a/manifest/efa-k8s-device-plugin.yml
+++ b/manifest/efa-k8s-device-plugin.yml
@@ -144,7 +144,7 @@ spec:
                     - hpc7g.16xlarge
       hostNetwork: true
       containers:
-        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin:v0.5.0
+        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin:v0.5.1
           name: aws-efa-k8s-device-plugin
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Updated image to `v0.5.1`, tested by applying manifest and observing successful logs on a `p5.48xlarge` machine

```
2024/03/22 17:14:55 Fetching EFA devices.
2024/03/22 17:14:55 device: rdmap79s0,uverbs0,/sys/class/infiniband_verbs/uverbs0,/sys/class/infiniband/rdmap79s0

2024/03/22 17:14:55 device: rdmap80s0,uverbs1,/sys/class/infiniband_verbs/uverbs1,/sys/class/infiniband/rdmap80s0

2024/03/22 17:14:55 device: rdmap81s0,uverbs2,/sys/class/infiniband_verbs/uverbs2,/sys/class/infiniband/rdmap81s0

2024/03/22 17:14:55 device: rdmap82s0,uverbs3,/sys/class/infiniband_verbs/uverbs3,/sys/class/infiniband/rdmap82s0

2024/03/22 17:14:55 device: rdmap96s0,uverbs4,/sys/class/infiniband_verbs/uverbs4,/sys/class/infiniband/rdmap96s0

2024/03/22 17:14:55 device: rdmap97s0,uverbs5,/sys/class/infiniband_verbs/uverbs5,/sys/class/infiniband/rdmap97s0

2024/03/22 17:14:55 device: rdmap98s0,uverbs6,/sys/class/infiniband_verbs/uverbs6,/sys/class/infiniband/rdmap98s0

2024/03/22 17:14:55 device: rdmap99s0,uverbs7,/sys/class/infiniband_verbs/uverbs7,/sys/class/infiniband/rdmap99s0

2024/03/22 17:14:55 device: rdmap113s0,uverbs8,/sys/class/infiniband_verbs/uverbs8,/sys/class/infiniband/rdmap113s0

2024/03/22 17:14:55 device: rdmap114s0,uverbs9,/sys/class/infiniband_verbs/uverbs9,/sys/class/infiniband/rdmap114s0

2024/03/22 17:14:55 device: rdmap115s0,uverbs10,/sys/class/infiniband_verbs/uverbs10,/sys/class/infiniband/rdmap115s0

2024/03/22 17:14:55 device: rdmap116s0,uverbs11,/sys/class/infiniband_verbs/uverbs11,/sys/class/infiniband/rdmap116s0

2024/03/22 17:14:55 device: rdmap130s0,uverbs12,/sys/class/infiniband_verbs/uverbs12,/sys/class/infiniband/rdmap130s0

2024/03/22 17:14:55 device: rdmap131s0,uverbs13,/sys/class/infiniband_verbs/uverbs13,/sys/class/infiniband/rdmap131s0

2024/03/22 17:14:55 device: rdmap132s0,uverbs14,/sys/class/infiniband_verbs/uverbs14,/sys/class/infiniband/rdmap132s0

2024/03/22 17:14:55 device: rdmap133s0,uverbs15,/sys/class/infiniband_verbs/uverbs15,/sys/class/infiniband/rdmap133s0

2024/03/22 17:14:55 device: rdmap147s0,uverbs16,/sys/class/infiniband_verbs/uverbs16,/sys/class/infiniband/rdmap147s0

2024/03/22 17:14:55 device: rdmap148s0,uverbs17,/sys/class/infiniband_verbs/uverbs17,/sys/class/infiniband/rdmap148s0

2024/03/22 17:14:55 device: rdmap149s0,uverbs18,/sys/class/infiniband_verbs/uverbs18,/sys/class/infiniband/rdmap149s0

2024/03/22 17:14:55 device: rdmap150s0,uverbs19,/sys/class/infiniband_verbs/uverbs19,/sys/class/infiniband/rdmap150s0

2024/03/22 17:14:55 device: rdmap164s0,uverbs20,/sys/class/infiniband_verbs/uverbs20,/sys/class/infiniband/rdmap164s0

2024/03/22 17:14:55 device: rdmap165s0,uverbs21,/sys/class/infiniband_verbs/uverbs21,/sys/class/infiniband/rdmap165s0

2024/03/22 17:14:55 device: rdmap166s0,uverbs22,/sys/class/infiniband_verbs/uverbs22,/sys/class/infiniband/rdmap166s0

2024/03/22 17:14:55 device: rdmap167s0,uverbs23,/sys/class/infiniband_verbs/uverbs23,/sys/class/infiniband/rdmap167s0

2024/03/22 17:14:55 device: rdmap181s0,uverbs24,/sys/class/infiniband_verbs/uverbs24,/sys/class/infiniband/rdmap181s0

2024/03/22 17:14:55 device: rdmap182s0,uverbs25,/sys/class/infiniband_verbs/uverbs25,/sys/class/infiniband/rdmap182s0

2024/03/22 17:14:55 device: rdmap183s0,uverbs26,/sys/class/infiniband_verbs/uverbs26,/sys/class/infiniband/rdmap183s0

2024/03/22 17:14:55 device: rdmap184s0,uverbs27,/sys/class/infiniband_verbs/uverbs27,/sys/class/infiniband/rdmap184s0

2024/03/22 17:14:55 device: rdmap198s0,uverbs28,/sys/class/infiniband_verbs/uverbs28,/sys/class/infiniband/rdmap198s0

2024/03/22 17:14:55 device: rdmap199s0,uverbs29,/sys/class/infiniband_verbs/uverbs29,/sys/class/infiniband/rdmap199s0

2024/03/22 17:14:55 device: rdmap200s0,uverbs30,/sys/class/infiniband_verbs/uverbs30,/sys/class/infiniband/rdmap200s0

2024/03/22 17:14:55 device: rdmap201s0,uverbs31,/sys/class/infiniband_verbs/uverbs31,/sys/class/infiniband/rdmap201s0

2024/03/22 17:14:55 EFA Device list: [{rdmap79s0 uverbs0 /sys/class/infiniband_verbs/uverbs0 /sys/class/infiniband/rdmap79s0} {rdmap80s0 uverbs1 /sys/class/infiniband_verbs/uverbs1 /sys/class/infiniband/rdmap80s0} {rdmap81s0 uverbs2 /sys/class/infiniband_verbs/uverbs2 /sys/class/infiniband/rdmap81s0} {rdmap82s0 uverbs3 /sys/class/infiniband_verbs/uverbs3 /sys/class/infiniband/rdmap82s0} {rdmap96s0 uverbs4 /sys/class/infiniband_verbs/uverbs4 /sys/class/infiniband/rdmap96s0} {rdmap97s0 uverbs5 /sys/class/infiniband_verbs/uverbs5 /sys/class/infiniband/rdmap97s0} {rdmap98s0 uverbs6 /sys/class/infiniband_verbs/uverbs6 /sys/class/infiniband/rdmap98s0} {rdmap99s0 uverbs7 /sys/class/infiniband_verbs/uverbs7 /sys/class/infiniband/rdmap99s0} {rdmap113s0 uverbs8 /sys/class/infiniband_verbs/uverbs8 /sys/class/infiniband/rdmap113s0} {rdmap114s0 uverbs9 /sys/class/infiniband_verbs/uverbs9 /sys/class/infiniband/rdmap114s0} {rdmap115s0 uverbs10 /sys/class/infiniband_verbs/uverbs10 /sys/class/infiniband/rdmap115s0} {rdmap116s0 uverbs11 /sys/class/infiniband_verbs/uverbs11 /sys/class/infiniband/rdmap116s0} {rdmap130s0 uverbs12 /sys/class/infiniband_verbs/uverbs12 /sys/class/infiniband/rdmap130s0} {rdmap131s0 uverbs13 /sys/class/infiniband_verbs/uverbs13 /sys/class/infiniband/rdmap131s0} {rdmap132s0 uverbs14 /sys/class/infiniband_verbs/uverbs14 /sys/class/infiniband/rdmap132s0} {rdmap133s0 uverbs15 /sys/class/infiniband_verbs/uverbs15 /sys/class/infiniband/rdmap133s0} {rdmap147s0 uverbs16 /sys/class/infiniband_verbs/uverbs16 /sys/class/infiniband/rdmap147s0} {rdmap148s0 uverbs17 /sys/class/infiniband_verbs/uverbs17 /sys/class/infiniband/rdmap148s0} {rdmap149s0 uverbs18 /sys/class/infiniband_verbs/uverbs18 /sys/class/infiniband/rdmap149s0} {rdmap150s0 uverbs19 /sys/class/infiniband_verbs/uverbs19 /sys/class/infiniband/rdmap150s0} {rdmap164s0 uverbs20 /sys/class/infiniband_verbs/uverbs20 /sys/class/infiniband/rdmap164s0} {rdmap165s0 uverbs21 /sys/class/infiniband_verbs/uverbs21 /sys/class/infiniband/rdmap165s0} {rdmap166s0 uverbs22 /sys/class/infiniband_verbs/uverbs22 /sys/class/infiniband/rdmap166s0} {rdmap167s0 uverbs23 /sys/class/infiniband_verbs/uverbs23 /sys/class/infiniband/rdmap167s0} {rdmap181s0 uverbs24 /sys/class/infiniband_verbs/uverbs24 /sys/class/infiniband/rdmap181s0} {rdmap182s0 uverbs25 /sys/class/infiniband_verbs/uverbs25 /sys/class/infiniband/rdmap182s0} {rdmap183s0 uverbs26 /sys/class/infiniband_verbs/uverbs26 /sys/class/infiniband/rdmap183s0} {rdmap184s0 uverbs27 /sys/class/infiniband_verbs/uverbs27 /sys/class/infiniband/rdmap184s0} {rdmap198s0 uverbs28 /sys/class/infiniband_verbs/uverbs28 /sys/class/infiniband/rdmap198s0} {rdmap199s0 uverbs29 /sys/class/infiniband_verbs/uverbs29 /sys/class/infiniband/rdmap199s0} {rdmap200s0 uverbs30 /sys/class/infiniband_verbs/uverbs30 /sys/class/infiniband/rdmap200s0} {rdmap201s0 uverbs31 /sys/class/infiniband_verbs/uverbs31 /sys/class/infiniband/rdmap201s0}]
2024/03/22 17:14:55 Starting FS watcher.
2024/03/22 17:14:55 Starting OS watcher.
2024/03/22 17:14:55 device: rdmap79s0,uverbs0,/sys/class/infiniband_verbs/uverbs0,/sys/class/infiniband/rdmap79s0

2024/03/22 17:14:55 device: rdmap80s0,uverbs1,/sys/class/infiniband_verbs/uverbs1,/sys/class/infiniband/rdmap80s0

2024/03/22 17:14:55 device: rdmap81s0,uverbs2,/sys/class/infiniband_verbs/uverbs2,/sys/class/infiniband/rdmap81s0

2024/03/22 17:14:55 device: rdmap82s0,uverbs3,/sys/class/infiniband_verbs/uverbs3,/sys/class/infiniband/rdmap82s0

2024/03/22 17:14:55 device: rdmap96s0,uverbs4,/sys/class/infiniband_verbs/uverbs4,/sys/class/infiniband/rdmap96s0

2024/03/22 17:14:55 device: rdmap97s0,uverbs5,/sys/class/infiniband_verbs/uverbs5,/sys/class/infiniband/rdmap97s0

2024/03/22 17:14:55 device: rdmap98s0,uverbs6,/sys/class/infiniband_verbs/uverbs6,/sys/class/infiniband/rdmap98s0

2024/03/22 17:14:55 device: rdmap99s0,uverbs7,/sys/class/infiniband_verbs/uverbs7,/sys/class/infiniband/rdmap99s0

2024/03/22 17:14:55 device: rdmap113s0,uverbs8,/sys/class/infiniband_verbs/uverbs8,/sys/class/infiniband/rdmap113s0

2024/03/22 17:14:55 device: rdmap114s0,uverbs9,/sys/class/infiniband_verbs/uverbs9,/sys/class/infiniband/rdmap114s0

2024/03/22 17:14:55 device: rdmap115s0,uverbs10,/sys/class/infiniband_verbs/uverbs10,/sys/class/infiniband/rdmap115s0

2024/03/22 17:14:55 device: rdmap116s0,uverbs11,/sys/class/infiniband_verbs/uverbs11,/sys/class/infiniband/rdmap116s0

2024/03/22 17:14:55 device: rdmap130s0,uverbs12,/sys/class/infiniband_verbs/uverbs12,/sys/class/infiniband/rdmap130s0

2024/03/22 17:14:55 device: rdmap131s0,uverbs13,/sys/class/infiniband_verbs/uverbs13,/sys/class/infiniband/rdmap131s0

2024/03/22 17:14:55 device: rdmap132s0,uverbs14,/sys/class/infiniband_verbs/uverbs14,/sys/class/infiniband/rdmap132s0

2024/03/22 17:14:55 device: rdmap133s0,uverbs15,/sys/class/infiniband_verbs/uverbs15,/sys/class/infiniband/rdmap133s0

2024/03/22 17:14:55 device: rdmap147s0,uverbs16,/sys/class/infiniband_verbs/uverbs16,/sys/class/infiniband/rdmap147s0

2024/03/22 17:14:55 device: rdmap148s0,uverbs17,/sys/class/infiniband_verbs/uverbs17,/sys/class/infiniband/rdmap148s0

2024/03/22 17:14:55 device: rdmap149s0,uverbs18,/sys/class/infiniband_verbs/uverbs18,/sys/class/infiniband/rdmap149s0

2024/03/22 17:14:55 device: rdmap150s0,uverbs19,/sys/class/infiniband_verbs/uverbs19,/sys/class/infiniband/rdmap150s0

2024/03/22 17:14:55 device: rdmap164s0,uverbs20,/sys/class/infiniband_verbs/uverbs20,/sys/class/infiniband/rdmap164s0

2024/03/22 17:14:55 device: rdmap165s0,uverbs21,/sys/class/infiniband_verbs/uverbs21,/sys/class/infiniband/rdmap165s0

2024/03/22 17:14:55 device: rdmap166s0,uverbs22,/sys/class/infiniband_verbs/uverbs22,/sys/class/infiniband/rdmap166s0

2024/03/22 17:14:55 device: rdmap167s0,uverbs23,/sys/class/infiniband_verbs/uverbs23,/sys/class/infiniband/rdmap167s0

2024/03/22 17:14:55 device: rdmap181s0,uverbs24,/sys/class/infiniband_verbs/uverbs24,/sys/class/infiniband/rdmap181s0

2024/03/22 17:14:55 device: rdmap182s0,uverbs25,/sys/class/infiniband_verbs/uverbs25,/sys/class/infiniband/rdmap182s0

2024/03/22 17:14:55 device: rdmap183s0,uverbs26,/sys/class/infiniband_verbs/uverbs26,/sys/class/infiniband/rdmap183s0

2024/03/22 17:14:55 device: rdmap184s0,uverbs27,/sys/class/infiniband_verbs/uverbs27,/sys/class/infiniband/rdmap184s0

2024/03/22 17:14:55 device: rdmap198s0,uverbs28,/sys/class/infiniband_verbs/uverbs28,/sys/class/infiniband/rdmap198s0

2024/03/22 17:14:55 device: rdmap199s0,uverbs29,/sys/class/infiniband_verbs/uverbs29,/sys/class/infiniband/rdmap199s0

2024/03/22 17:14:55 device: rdmap200s0,uverbs30,/sys/class/infiniband_verbs/uverbs30,/sys/class/infiniband/rdmap200s0

2024/03/22 17:14:55 device: rdmap201s0,uverbs31,/sys/class/infiniband_verbs/uverbs31,/sys/class/infiniband/rdmap201s0

2024/03/22 17:14:55 Starting to serve on /var/lib/kubelet/device-plugins/aws-efa-device-plugin.sock
2024/03/22 17:14:55 Registered device plugin with Kubelet
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
